### PR TITLE
Drop anchors in headings

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -3,7 +3,6 @@ title = "Blog"
 template = "section.html"
 sort_by = "date"
 paginate_by = 5
-insert_anchor_links = "left"
 
 [extra]
 show_previous_next_article_links = true

--- a/content/pages/how-it-works.md
+++ b/content/pages/how-it-works.md
@@ -2,7 +2,6 @@
 title = "How it Works"
 template = "info-page.html"
 path = "how-it-works"
-insert_anchor_links = "left"
 
 [extra]
 header = { title = "How it Works" }


### PR DESCRIPTION
To keep the website uncluttered, especially for screen reader users, let's not include anchors in headings.