### PR TITLE
Fix the opening of the 2022 retrospective blog post

### DIFF
--- a/content/blog/001_looking_back_looking_forward.md
+++ b/content/blog/001_looking_back_looking_forward.md
@@ -5,8 +5,6 @@ authors = ["Matt Campbell"]
 date = 2023-01-01T19:59:24Z
 +++
 
-a message from our founder
-
 2022 has been a great year for AccessKit, thanks to continued funding from the Google Fonts team. As we celebrate the new year, I’d like to look back on what we’ve accomplished in 2022, and look forward to the work that still needs to be done to fulfill AccessKit’s potential.
 
 ## Progress in 2022


### PR DESCRIPTION
Beginning the 2022 retrospective post with "a  message from our founder" was *not* my idea. It was added by the person who managed the old website on my behalf, and looking back at it now, it doesn't fit the tone I want for the website.